### PR TITLE
replace iam creds with default authType for role assume on cloudwatch datasource

### DIFF
--- a/datasources/cloudwatch.yaml
+++ b/datasources/cloudwatch.yaml
@@ -3,9 +3,6 @@ datasources:
 - name: CloudWatch
   type: cloudwatch
   jsonData:
-     authType: keys
+     authType: default
      defaultRegion: eu-west-1
-  secureJsonData:
-    accessKey: "$(GRAFANA_CLOUDWATCH_KEY)"
-    secretKey: "$(GRAFANA_CLOUDWATCH_SECRET)"
   editable: false


### PR DESCRIPTION
This PR edits the grafana datasource for cloudwatch to use the default authtype instead of the iam key and secret. This will allow it to use the role assigned to the pod via an annotation

DO NOT MERGE UNTIL https://github.com/dfds/infrastructure-modules/pull/203 is deployed otherwise dashboards using Cloudwatch metrics will fail