### PR TITLE
Increased threshold for kafka consumer groups

### DIFF
--- a/dashboards/Kafka exporter.json
+++ b/dashboards/Kafka exporter.json
@@ -22,7 +22,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 45,
+  "id": 35,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -33,7 +33,7 @@
           {
             "evaluator": {
               "params": [
-                50
+                150
               ],
               "type": "gt"
             },
@@ -148,7 +148,7 @@
         {
           "colorMode": "critical",
           "op": "gt",
-          "value": 50,
+          "value": 150,
           "visible": true
         }
       ],
@@ -299,6 +299,6 @@
   "timezone": "",
   "title": "Kafka-exporter",
   "uid": "CoYn_3-nk",
-  "version": 5,
+  "version": 1,
   "weekStart": ""
 }


### PR DESCRIPTION
This PR will increase the threshold for the kafka consumer group alert. If we continue to get alerts triggered we will need to look at replacing the central kafka-exporter with a kafka-exporter per team who want kafka metrics.