### PR TITLE
feat: add watchdog alert

### DIFF
--- a/alerts/cluster.yaml
+++ b/alerts/cluster.yaml
@@ -1759,3 +1759,90 @@ groups:
         labels:
           rule_uid: b8eaf085-5c81-4d2a-b4a7-f2c6c9998e66
         isPaused: false
+  - orgId: 1
+    name: Watchdog
+    folder: General Alerting
+    interval: 5m
+    rules:
+      - uid: d9806634-6a2e-4bbd-965a-59d602064de5
+        title: Watchdog
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: prometheus
+            model:
+              editorMode: code
+              expr: vector(1)
+              hide: false
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              range: false
+              refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              conditions:
+                  - evaluator:
+                      params: []
+                      type: gt
+                    operator:
+                      type: and
+                    query:
+                      params:
+                          - B
+                    reducer:
+                      params: []
+                      type: last
+                    type: query
+              datasource:
+                  type: __expr__
+                  uid: __expr__
+              expression: A
+              hide: false
+              intervalMs: 1000
+              maxDataPoints: 43200
+              reducer: last
+              refId: B
+              type: reduce
+          - refId: C
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              conditions:
+                  - evaluator:
+                      params:
+                          - 0
+                      type: gt
+                    operator:
+                      type: and
+                    query:
+                      params:
+                          - C
+                    reducer:
+                      params: []
+                      type: last
+                    type: query
+              datasource:
+                  type: __expr__
+                  uid: __expr__
+              expression: B
+              hide: false
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+        noDataState: NoData
+        execErrState: Error
+        for: 5m
+        labels:
+          repeat: 24h
+        isPaused: false


### PR DESCRIPTION
This PR adds a Watchdog alert to Grafana with a "repeat: 24h" label so that it is routed to the 24h notifier in https://github.com/dfds/infrastructure-modules/pull/1165