### PR TITLE
fix: k8s version alert use repeat 24h

### DIFF
--- a/alerts/cluster.yaml
+++ b/alerts/cluster.yaml
@@ -1709,6 +1709,7 @@ groups:
           message: Current Kubernetes cluster version is outdated
         labels:
           rule_uid: b3144065-3094-4403-93dd-b7037b9f563d
+          repeat: 24h
         isPaused: false
   - orgId: 1
     name: Volume Snapshot Failure alert


### PR DESCRIPTION
This PR adds the repeat: 24h label to the k8s outdated version alerts to prevent it spamming the channel every 4 hours

https://github.com/dfds/cloudplatform/issues/2116
