### PR TITLE
fix: modify cni count rule to compensate for gpu nodes having differe…

### DIFF
--- a/alerts/cluster.yaml
+++ b/alerts/cluster.yaml
@@ -216,7 +216,7 @@ groups:
               to: 0
             datasourceUid: prometheus
             model:
-              expr: count(count by (image) (kube_pod_container_info{namespace="kube-system", container="aws-node"})) - 1
+              expr: count(count by (image) (kube_pod_container_info{namespace="kube-system", container="aws-node"})) - 2
               format: time_series
               intervalFactor: 1
               legendFormat: cni

--- a/dashboards/Kubernetes Components.json
+++ b/dashboards/Kubernetes Components.json
@@ -683,7 +683,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "count(count by (image) (kube_pod_container_info{namespace=\"kube-system\", container=\"aws-node\"})) - 1",
+          "expr": "count(count by (image) (kube_pod_container_info{namespace=\"kube-system\", container=\"aws-node\"})) - 2",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "cni",


### PR DESCRIPTION
…nt aws-node image

This PR edits the expression to compensate for AWS GPU nodes having a different aws-node container image and triggering an alert to detect drift between our nodes