### PR TITLE
fix: modify kubelet rule to compensate for ami difference

### DIFF
--- a/alerts/cluster.yaml
+++ b/alerts/cluster.yaml
@@ -249,7 +249,7 @@ groups:
               to: 0
             datasourceUid: prometheus
             model:
-              expr: count(count by (kubelet_version) (kube_node_info)) - 1
+              expr: count(count by (kubelet_version) (kube_node_info)) - 2
               format: time_series
               intervalFactor: 1
               legendFormat: kubelet

--- a/dashboards/Kubernetes Components.json
+++ b/dashboards/Kubernetes Components.json
@@ -704,7 +704,7 @@
           "refId": "C"
         },
         {
-          "expr": "count(count by (kubelet_version) (kube_node_info)) - 1",
+          "expr": "count(count by (kubelet_version) (kube_node_info)) - 2",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "kubelet",


### PR DESCRIPTION
I don't like this as a fix because eventually the AMI's can align and we are left with a -1 value where it should be 0, but this deals with it for now while still being able to detect drift. I will create an issue to look at a better solution